### PR TITLE
Version bump

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -27,6 +27,8 @@ module.exports = function (grunt) {
 					"src/factory.js",
 					"src/cache.js",
 					"src/cached.js",
+					"src/compressed.js",
+					"src/compression.js",
 					"src/echo.js",
 					"src/error.js",
 					"src/hash.js",

--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2012 Jason Mulligan
  * @license BSD-3 <http://opensource.org/licenses/BSD-3-Clause>
  * @link https://github.com/avoidwork/turtle.io
- * @version 0.3.5
+ * @version 0.4.0
  */
 
 (function (global) {
@@ -96,7 +96,7 @@ var bootstrap = function (args) {
 		"Content-Type"                 : "text/html; charset=utf-8",
 		"Date"                         : "",
 		"Last-Modified"                : "",
-		"Server"                       : "turtle.io/0.3.5",
+		"Server"                       : "turtle.io/0.4.0",
 		"X-Powered-By"                 : (function () { return ("abaaso/" + $.version + " node.js/" + process.versions.node.replace(/^v/, "") + " (" + process.platform.capitalize() + " V8/" + process.versions.v8 + ")"); })(),
 		"Access-Control-Allow-Headers" : "Accept, Allow, Cache-Control, Content-Type, Date, Etag, Transfer-Encoding, Server",
 		"Access-Control-Allow-Methods" : "",
@@ -233,7 +233,7 @@ var factory = function (args) {
 	this.id      = "";
 	this.config  = {};
 	this.server  = null;
-	this.version = "0.3.5";
+	this.version = "0.4.0";
 
 	bootstrap.call(self, args);
 
@@ -247,14 +247,13 @@ var factory = function (args) {
  * @param  {String}   obj      Body or Path to file to compress
  * @param  {Function} format   Compression format (deflate or gzip)
  * @param  {Boolean}  body     [Optional] Indicates obj is the Body of a Response (default is false)
- * @return {Undefined}         undefined
+ * @return {Objet}             Instance
  */
 factory.prototype.cache = function (filename, obj, encoding, body) {
 	body      = (body === true);
 	var self  = this,
 	    tmp   = this.config.tmp,
-	    regex = /deflate/,
-	    ext   = regex.test(encoding) ? ".df" : ".gz",
+	    ext   = REGEX_DEF.test(encoding) ? ".df" : ".gz",
 	    dest  = tmp + "/" + filename + ext;
 
 	if (!body) {
@@ -262,7 +261,7 @@ factory.prototype.cache = function (filename, obj, encoding, body) {
 			var raw    = fs.createReadStream(obj),
 			    stream = fs.createWriteStream(dest);
 
-			raw.pipe(zlib[regex.test(encoding) ? "createDeflate" : "createGzip"]()).pipe(stream);
+			raw.pipe(zlib[REGEX_DEF.test(encoding) ? "createDeflate" : "createGzip"]()).pipe(stream);
 		});
 	}
 	else {
@@ -272,15 +271,17 @@ factory.prototype.cache = function (filename, obj, encoding, body) {
 			case obj instanceof Object:
 				obj = $.encode(obj);
 				break;
-			case obj instanceof Document:
+			/*case obj instanceof Document:
 				obj = $.xml.decode(obj);
-				break;
+				break;*/
 		}
 		zlib[encoding](obj, function (err, compressed) {
 			if (!err) fs.writeFile(dest, compressed);
 			else self.log(err, true, false);
 		});
 	}
+
+	return this;
 };
 
 /**
@@ -289,7 +290,7 @@ factory.prototype.cache = function (filename, obj, encoding, body) {
  * @param  {String}   filename Filename (etag)
  * @param  {String}   format   Type of compression (gzip or deflate)
  * @param  {Function} fn       Callback function
- * @return {Undefiend}         undefined
+ * @return {Objet}             Instance
  */
 factory.prototype.cached = function (filename, format, fn) {
 	var ext  = /deflate/.test(format) ? ".df" : ".gz",
@@ -298,6 +299,108 @@ factory.prototype.cached = function (filename, format, fn) {
 	fs.exists(path, function (exists) {
 		fn(exists, path);
 	});
+
+	return this;
+};
+
+/**
+ * Pipes compressed asset to Client, or schedules the creation of the asset
+ * 
+ * @param  {Object}  res     HTTP response Object
+ * @param  {Object}  req     HTTP request Object
+ * @param  {String}  etag    Etag header
+ * @param  {String}  arg     Response body
+ * @param  {Number}  code    Response status code
+ * @param  {Object}  headers HTTP headers
+ * @param  {Boolean} local   [Optional] Indicates arg is a file path, default is false
+ * @return {Objet}          Instance
+ */
+factory.prototype.compressed = function (res, req, etag, arg, code, headers, local) {
+	local           = (local === true);
+	var self        = this,
+	    compression = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
+	    raw;
+
+	
+	// Local asset, piping result directly to Client
+	if (local) {
+		if (compression !== null) {
+			res.setHeader("Content-Encoding", compression);
+			self.cached(etag, compression, function (ready, npath) {
+				if (ready) {
+					self.headers(res, req, code, headers);
+					raw = fs.createReadStream(npath);
+					raw.pipe(res);
+				}
+				else {
+					self.cache(etag, arg, compression);
+					raw = fs.createReadStream(arg);
+					raw.pipe(zlib[REGEX_DEF.test(compression) ? "createDeflate" : "createGzip"]()).pipe(res);
+				}
+			});
+		}
+		else {
+			raw = fs.createReadStream(arg);
+			util.pump(raw, res);
+		}
+	}
+	// Proxy response
+	else {
+		if (compression !== null) {
+			res.setHeader("Content-Encoding", compression);
+			self.cached(etag, compression, function (ready, npath) {
+				if (ready) {
+					self.headers(res, req, code, headers);
+					raw = fs.createReadStream(npath);
+					raw.pipe(res);
+				}
+				else {
+					self.cache(etag, arg, compression, true);
+					self.respond(res, req, arg, code, headers);
+				}
+			});
+		}
+		else this.respond(res, req, arg, code, headers, false);
+	}
+
+	return this;
+};
+
+
+/**
+ * Determines what/if compression is supported for a request
+ * 
+ * @param  {String} agent    User-Agent header value
+ * @param  {String} encoding Accept-Encoding header value
+ * @return {Mixed}           Supported compression or null
+ */
+factory.prototype.compression = function (agent, encoding) {
+	var result    = "",
+	    encodings = typeof encoding === "string" ? encoding.explode(",") : [],
+	    nth       = encodings.length - 1;
+
+	
+	if (!REGEX_IE.test(agent)) {
+		// Iterating supported encodings
+		encodings.each(function (i, idx) {
+			switch (true) {
+				case REGEX_GZIP.test(i):
+					result = "gzip";
+					break;
+				case REGEX_DEF.test(i):
+					result = "deflate";
+					break;
+			}
+
+			// Found a supported encoding
+			if (!result.isEmpty()) return false;
+		});
+	}
+
+	// Setting null to imply no compression is supported
+	if (result.isEmpty()) result = null;
+
+	return result;
 };
 
 /**
@@ -360,9 +463,8 @@ factory.prototype.hash = function (arg, encrypt, digest) {
  * @return {Objet}                   Instance
  */
 factory.prototype.headers = function (res, req, status, responseHeaders) {
-	var get      = REGEX_GET.test(req.method),
-	    headers  = $.clone(this.config.headers),
-	    compression;
+	var get     = REGEX_GET.test(req.method),
+	    headers = $.clone(this.config.headers);
 
 	// Setting optional params
 	if (typeof status === "undefined") status = codes.SUCCESS;
@@ -378,6 +480,9 @@ factory.prototype.headers = function (res, req, status, responseHeaders) {
 	// Setting the response status code
 	res.statusCode = status;
 
+	// Decorating "Last-Modified" header
+	if (headers["Last-Modified"].isEmpty()) headers["Last-Modified"] = headers["Date"];
+
 	// Removing headers not wanted in the response
 	if (!get || status >= codes.INVALID_ARGUMENTS) delete headers["Cache-Control"];
 	switch (true) {
@@ -390,7 +495,9 @@ factory.prototype.headers = function (res, req, status, responseHeaders) {
 	}
 
 	// Decorating response with headers
-	$.iterate(headers, function (v, k) { res.setHeader(k, v); });
+	$.iterate(headers, function (v, k) {
+		res.setHeader(k, v);
+	});
 
 	return this;
 };
@@ -467,8 +574,7 @@ factory.prototype.proxy = function (origin, route, host) {
 		var resHeaders = {},
 		    etag       = "",
 		    date       = "",
-		    ie         = REGEX_IE.test(req.headers["user-agent"]),
-		    raw;
+		    nth, raw;
 
 		try {
 			// Getting or creating an Etag
@@ -477,44 +583,19 @@ factory.prototype.proxy = function (origin, route, host) {
 			if (isNaN(new Date(date).getFullYear())) date = undefined;
 			etag       = resHeaders.Etag || "\"" + self.hash(resHeaders["Content-Length"] + "-" + new Date(date).getTime()) + "\"";
 
-			// Setting headers
-			resHeaders["Transfer-Encoding"] = "chunked";
+			// Setting header
 			if (resHeaders.Etag !== etag) resHeaders.Etag = etag;
 
-			// Looking for a cached version
-			etag = etag.replace(/\"/g, "");
-
+			// Determining if a 304 response is valid based on Etag only (no timestamp is kept)
 			switch (true) {
-				case !ie && REGEX_DEF.test(req.headers["accept-encoding"]):
-					res.setHeader("Content-Encoding", "deflate");
-					self.cached(etag, "deflate", function (ready, npath) {
-						if (ready) {
-							self.headers(res, req, codes.SUCCESS, resHeaders);
-							raw = fs.createReadStream(npath);
-							raw.pipe(res);
-						}
-						else {
-							self.cache(etag, arg, "deflate", true);
-							self.respond(res, req, arg, xhr.status, resHeaders);
-						}
-					});
-					break;
-				case !ie && REGEX_GZIP.test(req.headers["accept-encoding"]):
-					res.setHeader("Content-Encoding", "gzip");
-					self.cached(etag, "gzip", function (ready, npath) {
-						if (ready) {
-							self.headers(res, req, codes.SUCCESS, resHeaders);
-							raw = fs.createReadStream(npath);
-							raw.pipe(res);
-						}
-						else {
-							self.cache(etag, arg, "gzip", true);
-							self.respond(res, req, arg, xhr.status, resHeaders);
-						}
-					});
+				case req.headers["if-none-match"] === etag:
+					self.headers(res, req, codes.NOT_MODIFIED, headers);
+					res.end();
 					break;
 				default:
-					self.respond(res, req, arg, xhr.status, resHeaders);
+					resHeaders["Transfer-Encoding"] = "chunked";
+					etag = etag.replace(/\"/g, "");
+					self.compressed(res, req, etag, arg, xhr.status, resHeaders);
 			}
 		}
 		catch (e) {
@@ -631,8 +712,7 @@ factory.prototype.request = function (res, req) {
 						case "options":
 							mimetype = mime.lookup(path);
 							fs.stat(path, function (err, stat) {
-								var ie = REGEX_IE.test(req.headers["user-agent"]),
-								    size, modified, etag, raw, headers;
+								var size, modified, etag, raw, headers;
 
 								if (err) error(err);
 								else {
@@ -652,39 +732,7 @@ factory.prototype.request = function (res, req) {
 												headers["Transfer-Encoding"] = "chunked";
 												self.headers(res, req, codes.SUCCESS, headers);
 												etag = etag.replace(/\"/g, "");
-												switch (true) {
-													case !ie && REGEX_DEF.test(req.headers["accept-encoding"]):
-														res.setHeader("Content-Encoding", "deflate");
-														self.cached(etag, "deflate", function (ready, npath) {
-															if (ready) {
-																raw = fs.createReadStream(npath);
-																raw.pipe(res);
-															}
-															else {
-																self.cache(etag, path, "deflate");
-																raw = fs.createReadStream(path);
-																raw.pipe(zlib.createDeflate()).pipe(res);
-															}
-														});
-														break;
-													case !ie && REGEX_GZIP.test(req.headers["accept-encoding"]):
-														res.setHeader("Content-Encoding", "gzip");
-														self.cached(etag, "gzip", function (ready, npath) {
-															if (ready) {
-																raw = fs.createReadStream(npath);
-																raw.pipe(res);
-															}
-															else {
-																self.cache(etag, path, "gzip");
-																raw = fs.createReadStream(path);
-																raw.pipe(zlib.createGzip()).pipe(res);
-															}
-														});
-														break;
-													default:
-														raw = fs.createReadStream(path);
-														util.pump(raw, res);
-												}
+												self.compressed(res, req, etag, path, codes.SUCCESS, headers, true);
 										}
 									}
 									else self.respond(res, req, messages.NO_CONTENT, codes.SUCCESS, headers);
@@ -735,25 +783,37 @@ factory.prototype.request = function (res, req) {
  * @param  {Mixed}   output          [Optional] Response
  * @param  {Number}  status          [Optional] HTTP status code, default is 200
  * @param  {Object}  responseHeaders [Optional] HTTP headers to decorate the response with
+ * @param  {Boolean} compress        [Optional] Enable compression of the response (if supported)
  * @return {Objet}                   Instance
  */
-factory.prototype.respond = function (res, req, output, status, responseHeaders) {
+factory.prototype.respond = function (res, req, output, status, responseHeaders, compress) {
 	if (typeof status === "undefined")        status          = codes.SUCCESS;
 	if (!(responseHeaders instanceof Object)) responseHeaders = {};
 
-	var body     = !REGEX_BODY.test(req.method),
-	    encoding = req.headers["accept-encoding"],
-	    compress = body && !REGEX_IE.test(req.headers["user-agent"]) && (REGEX_DEF.test(encoding) || REGEX_GZIP.test(encoding)),
-	    self     = this;
+	var body      = !REGEX_BODY.test(req.method),
+	    encoding  = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
+	    self      = this,
+	    nth;
 
-	// Encoding as JSON if not prepared
-	if (body && ((output instanceof Array) || String(output) === "[object Object]")) {
-		responseHeaders["Content-Type"] = "application/json";
-		output = $.encode(output);
+	// Determining wether compression is supported
+	compress = compress || (body && encoding !== null);
+
+	// Converting JSON or XML to a String
+	if (body) {
+		switch (true) {
+			case output instanceof Array:
+			case output instanceof Object:
+				responseHeaders["Content-Type"] = "application/json";
+				output = $.encode(output);
+				break;
+			/*case output instanceof Document:
+				responseHeaders["Content-Type"] = "application/xml";
+				output = $.xml.decode(output);
+				break;*/
+		}
 	}
 
 	if (compress) {
-		encoding = REGEX_DEF.test(encoding) ? "deflate" : "gzip";
 		responseHeaders["Content-Encoding"] = encoding;
 		zlib[encoding](output, function (err, compressed) {
 			if (err) self.error(res, req);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "homepage": "https://github.com/avoidwork/turtle.io",
   "author": {
     "name": "Jason Mulligan",

--- a/src/cache.js
+++ b/src/cache.js
@@ -5,7 +5,7 @@
  * @param  {String}   obj      Body or Path to file to compress
  * @param  {Function} format   Compression format (deflate or gzip)
  * @param  {Boolean}  body     [Optional] Indicates obj is the Body of a Response (default is false)
- * @return {Undefined}         undefined
+ * @return {Objet}             Instance
  */
 factory.prototype.cache = function (filename, obj, encoding, body) {
 	body      = (body === true);
@@ -29,13 +29,15 @@ factory.prototype.cache = function (filename, obj, encoding, body) {
 			case obj instanceof Object:
 				obj = $.encode(obj);
 				break;
-			case obj instanceof Document:
+			/*case obj instanceof Document:
 				obj = $.xml.decode(obj);
-				break;
+				break;*/
 		}
 		zlib[encoding](obj, function (err, compressed) {
 			if (!err) fs.writeFile(dest, compressed);
 			else self.log(err, true, false);
 		});
 	}
+
+	return this;
 };

--- a/src/cached.js
+++ b/src/cached.js
@@ -4,7 +4,7 @@
  * @param  {String}   filename Filename (etag)
  * @param  {String}   format   Type of compression (gzip or deflate)
  * @param  {Function} fn       Callback function
- * @return {Undefiend}         undefined
+ * @return {Objet}             Instance
  */
 factory.prototype.cached = function (filename, format, fn) {
 	var ext  = /deflate/.test(format) ? ".df" : ".gz",
@@ -13,4 +13,6 @@ factory.prototype.cached = function (filename, format, fn) {
 	fs.exists(path, function (exists) {
 		fn(exists, path);
 	});
+
+	return this;
 };

--- a/src/compressed.js
+++ b/src/compressed.js
@@ -1,0 +1,62 @@
+/**
+ * Pipes compressed asset to Client, or schedules the creation of the asset
+ * 
+ * @param  {Object}  res     HTTP response Object
+ * @param  {Object}  req     HTTP request Object
+ * @param  {String}  etag    Etag header
+ * @param  {String}  arg     Response body
+ * @param  {Number}  code    Response status code
+ * @param  {Object}  headers HTTP headers
+ * @param  {Boolean} local   [Optional] Indicates arg is a file path, default is false
+ * @return {Objet}          Instance
+ */
+factory.prototype.compressed = function (res, req, etag, arg, code, headers, local) {
+	local           = (local === true);
+	var self        = this,
+	    compression = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
+	    raw;
+
+	
+	// Local asset, piping result directly to Client
+	if (local) {
+		if (compression !== null) {
+			res.setHeader("Content-Encoding", compression);
+			self.cached(etag, compression, function (ready, npath) {
+				if (ready) {
+					self.headers(res, req, code, headers);
+					raw = fs.createReadStream(npath);
+					raw.pipe(res);
+				}
+				else {
+					self.cache(etag, arg, compression);
+					raw = fs.createReadStream(arg);
+					raw.pipe(zlib[REGEX_DEF.test(compression) ? "createDeflate" : "createGzip"]()).pipe(res);
+				}
+			});
+		}
+		else {
+			raw = fs.createReadStream(arg);
+			util.pump(raw, res);
+		}
+	}
+	// Proxy response
+	else {
+		if (compression !== null) {
+			res.setHeader("Content-Encoding", compression);
+			self.cached(etag, compression, function (ready, npath) {
+				if (ready) {
+					self.headers(res, req, code, headers);
+					raw = fs.createReadStream(npath);
+					raw.pipe(res);
+				}
+				else {
+					self.cache(etag, arg, compression, true);
+					self.respond(res, req, arg, code, headers);
+				}
+			});
+		}
+		else this.respond(res, req, arg, code, headers, false);
+	}
+
+	return this;
+};

--- a/src/compression.js
+++ b/src/compression.js
@@ -1,0 +1,36 @@
+
+/**
+ * Determines what/if compression is supported for a request
+ * 
+ * @param  {String} agent    User-Agent header value
+ * @param  {String} encoding Accept-Encoding header value
+ * @return {Mixed}           Supported compression or null
+ */
+factory.prototype.compression = function (agent, encoding) {
+	var result    = "",
+	    encodings = typeof encoding === "string" ? encoding.explode(",") : [],
+	    nth       = encodings.length - 1;
+
+	
+	if (!REGEX_IE.test(agent)) {
+		// Iterating supported encodings
+		encodings.each(function (i, idx) {
+			switch (true) {
+				case REGEX_GZIP.test(i):
+					result = "gzip";
+					break;
+				case REGEX_DEF.test(i):
+					result = "deflate";
+					break;
+			}
+
+			// Found a supported encoding
+			if (!result.isEmpty()) return false;
+		});
+	}
+
+	// Setting null to imply no compression is supported
+	if (result.isEmpty()) result = null;
+
+	return result;
+};

--- a/src/headers.js
+++ b/src/headers.js
@@ -8,9 +8,8 @@
  * @return {Objet}                   Instance
  */
 factory.prototype.headers = function (res, req, status, responseHeaders) {
-	var get      = REGEX_GET.test(req.method),
-	    headers  = $.clone(this.config.headers),
-	    compression;
+	var get     = REGEX_GET.test(req.method),
+	    headers = $.clone(this.config.headers);
 
 	// Setting optional params
 	if (typeof status === "undefined") status = codes.SUCCESS;
@@ -26,6 +25,9 @@ factory.prototype.headers = function (res, req, status, responseHeaders) {
 	// Setting the response status code
 	res.statusCode = status;
 
+	// Decorating "Last-Modified" header
+	if (headers["Last-Modified"].isEmpty()) headers["Last-Modified"] = headers["Date"];
+
 	// Removing headers not wanted in the response
 	if (!get || status >= codes.INVALID_ARGUMENTS) delete headers["Cache-Control"];
 	switch (true) {
@@ -38,7 +40,9 @@ factory.prototype.headers = function (res, req, status, responseHeaders) {
 	}
 
 	// Decorating response with headers
-	$.iterate(headers, function (v, k) { res.setHeader(k, v); });
+	$.iterate(headers, function (v, k) {
+		res.setHeader(k, v);
+	});
 
 	return this;
 };


### PR DESCRIPTION
- Refactored to support DRY
- Cached proxy responses can respond with 304 status code
- Compression is based on order of Accept-Encoding header (not looking for q=\* atm)
- Disabled XML support for this release
- Fixed return from new methods to support chaining
