### PR TITLE
Refactored proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ var config    = require("./config.json"),
     server    = new turtle_io();
 
 // Setting proxy routes
-server.proxy(config.api, "/api");
-server.proxy(config.api, "/api/[a-z]+");
-server.proxy(config.api, "/api/[a-z]+/[a-z0-9]+");
+server.proxy("http://api.abaaso.com", "/api");
 
 server.start(config);
 ```

--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2012 Jason Mulligan
  * @license BSD-3 <http://opensource.org/licenses/BSD-3-Clause>
  * @link https://github.com/avoidwork/turtle.io
- * @version 0.4.0
+ * @version 0.5.0
  */
 
 (function (global) {
@@ -96,7 +96,7 @@ var bootstrap = function (args) {
 		"Content-Type"                 : "text/html; charset=utf-8",
 		"Date"                         : "",
 		"Last-Modified"                : "",
-		"Server"                       : "turtle.io/0.4.0",
+		"Server"                       : "turtle.io/0.5.0",
 		"X-Powered-By"                 : (function () { return ("abaaso/" + $.version + " node.js/" + process.versions.node.replace(/^v/, "") + " (" + process.platform.capitalize() + " V8/" + process.versions.v8 + ")"); })(),
 		"Access-Control-Allow-Headers" : "Accept, Allow, Cache-Control, Content-Type, Date, Etag, Transfer-Encoding, Server",
 		"Access-Control-Allow-Methods" : "",
@@ -233,7 +233,7 @@ var factory = function (args) {
 	this.id      = "";
 	this.config  = {};
 	this.server  = null;
-	this.version = "0.4.0";
+	this.version = "0.5.0";
 
 	bootstrap.call(self, args);
 
@@ -549,7 +549,7 @@ factory.prototype.log = function (msg, error, display) {
 };
 
 /**
- * Proxies a request to a Server
+ * Proxies a (root) URL to a route
  * 
  * @param  {String} origin Host to proxy (e.g. http://hostname)
  * @param  {String} route  Route to proxy
@@ -574,6 +574,8 @@ factory.prototype.proxy = function (origin, route, host) {
 		var resHeaders = {},
 		    etag       = "",
 		    date       = "",
+		    regex      = /("|')\//g,
+		    replace    = "$1" + route + "/",
 		    nth, raw;
 
 		try {
@@ -595,6 +597,19 @@ factory.prototype.proxy = function (origin, route, host) {
 				default:
 					resHeaders["Transfer-Encoding"] = "chunked";
 					etag = etag.replace(/\"/g, "");
+
+					// Fixing root path of response
+					switch (true) {
+						case arg instanceof Array:
+						case arg instanceof Object:
+							arg = $.decode($.encode(arg).replace(regex, replace));
+							break;
+						case typeof arg === "string":
+							arg = arg.replace(regex, replace);
+							break;
+					}
+
+					// Ready to compress response
 					self.compressed(res, req, etag, arg, xhr.status, resHeaders);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/avoidwork/turtle.io",
   "author": {
     "name": "Jason Mulligan",

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,5 +1,5 @@
 /**
- * Proxies a request to a Server
+ * Proxies a (root) URL to a route
  * 
  * @param  {String} origin Host to proxy (e.g. http://hostname)
  * @param  {String} route  Route to proxy
@@ -24,6 +24,8 @@ factory.prototype.proxy = function (origin, route, host) {
 		var resHeaders = {},
 		    etag       = "",
 		    date       = "",
+		    regex      = /("|')\//g,
+		    replace    = "$1" + route + "/",
 		    nth, raw;
 
 		try {
@@ -45,6 +47,19 @@ factory.prototype.proxy = function (origin, route, host) {
 				default:
 					resHeaders["Transfer-Encoding"] = "chunked";
 					etag = etag.replace(/\"/g, "");
+
+					// Fixing root path of response
+					switch (true) {
+						case arg instanceof Array:
+						case arg instanceof Object:
+							arg = $.decode($.encode(arg).replace(regex, replace));
+							break;
+						case typeof arg === "string":
+							arg = arg.replace(regex, replace);
+							break;
+					}
+
+					// Ready to compress response
 					self.compressed(res, req, etag, arg, xhr.status, resHeaders);
 			}
 		}


### PR DESCRIPTION
- Refactored to support multiple versioned APIs
- Proxy a host to a route, e.g. `http://api.abaaso.com` to `/api`
- Automatic reconciliation of route in response
