### PR TITLE
Minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ server.proxy("http://api.abaaso.com", "/api");
 server.start(config);
 ```
 
+## DTrace
+
+DTrace is supported, but only one probe is active for now. To utilize this probe, which is named "connection", you need to look for "turtle-io".
+
+This probe will return the number of open socket connections, the ram used, and the ram allocated.
+
+```console
+sudo dtrace -Z -n 'turtle-io*:::connection{ trace(arg0); trace(arg1); trace(arg2); }'
+```
+
 ## License
 Copyright (c) 2012 Jason Mulligan  
 Licensed under the BSD-3 license.

--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2013 Jason Mulligan
  * @license BSD-3 <https://raw.github.com/avoidwork/turtle.io/master/LICENSE>
  * @link http://turtle.io
- * @version 0.5.20
+ * @version 0.5.21
  */
 
 (function (global) {
@@ -24,6 +24,9 @@ var $          = require("abaaso"),
     url        = require("url"),
     util       = require("util"),
     zlib       = require("zlib"),
+    d          = require("dtrace-provider"),
+    dtp        = d.createDTraceProvider("turtle-io"),
+    probes     = {},
     REGEX_BODY = /^(put|post)$/i,
     REGEX_HALT = new RegExp("^(ReferenceError|" + $.label.error.invalidArguments + ")$"),
     REGEX_HEAD = /^(head|options)$/i,
@@ -39,6 +42,10 @@ syslog.init("turtle_io", syslog.LOG_PID | syslog.LOG_ODELAY, syslog.LOG_LOCAL0);
 
 // Disabling abaaso observer
 $.discard(true);
+
+// Setting DTrace probes
+probes.connection = dtp.addProbe("connection", "int", "int", "int");
+dtp.enable();
 
 /**
  * Verifies a method is allowed on a URI
@@ -165,7 +172,7 @@ var factory = function (args) {
 	this.id      = "";
 	this.config  = {};
 	this.server  = null;
-	this.version = "0.5.20";
+	this.version = "0.5.21";
 
 	// Loading config
 	config.call(this, args);
@@ -850,7 +857,7 @@ factory.prototype.start = function (args) {
 
 	// Default headers
 	headers = {
-		"Server"       : "turtle.io/0.5.20",
+		"Server"       : "turtle.io/0.5.21",
 		"X-Powered-By" : (function () { return ("abaaso/" + $.version + " node.js/" + process.versions.node.replace(/^v/, "") + " (" + process.platform.capitalize() + " V8/" + process.versions.v8 + ")"); })()
 	};
 
@@ -886,6 +893,15 @@ factory.prototype.start = function (args) {
 
 	// Setting acceptable lag
 	toobusy.maxLag(this.config.lag);
+
+	// Socket probe
+	this.server.on("connection", function () {
+		probes.connection.fire(function (p) {
+			var ram = process.memoryUsage();
+
+			return [self.server.connections, ram.heapUsed, ram.heapTotal];
+		});
+	});
 
 	// Announcing state
 	this.log("Started turtle.io on port " + this.config.port);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",
@@ -33,7 +33,8 @@
     "moment": ">= 1.7.0",
     "http-auth" : ">= 1.2.2",
     "node-syslog" : ">= 1.1.6",
-    "toobusy" : ">= 0.2.1"
+    "toobusy" : ">= 0.2.1",
+    "dtrace-provider" : ">= 0.2.8"
   },
   "devDependencies": {
     "grunt": "~0.3.14"

--- a/src/intro.js
+++ b/src/intro.js
@@ -12,6 +12,9 @@ var $          = require("abaaso"),
     url        = require("url"),
     util       = require("util"),
     zlib       = require("zlib"),
+    d          = require("dtrace-provider"),
+    dtp        = d.createDTraceProvider("turtle-io"),
+    probes     = {},
     REGEX_BODY = /^(put|post)$/i,
     REGEX_HALT = new RegExp("^(ReferenceError|" + $.label.error.invalidArguments + ")$"),
     REGEX_HEAD = /^(head|options)$/i,
@@ -27,3 +30,7 @@ syslog.init("turtle_io", syslog.LOG_PID | syslog.LOG_ODELAY, syslog.LOG_LOCAL0);
 
 // Disabling abaaso observer
 $.discard(true);
+
+// Setting DTrace probes
+probes.connection = dtp.addProbe("connection", "int", "int", "int");
+dtp.enable();

--- a/src/start.js
+++ b/src/start.js
@@ -49,6 +49,15 @@ factory.prototype.start = function (args) {
 	// Setting acceptable lag
 	toobusy.maxLag(this.config.lag);
 
+	// Socket probe
+	this.server.on("connection", function () {
+		probes.connection.fire(function (p) {
+			var ram = process.memoryUsage();
+
+			return [self.server.connections, ram.heapUsed, ram.heapTotal];
+		});
+	});
+
 	// Announcing state
 	this.log("Started turtle.io on port " + this.config.port);
 


### PR DESCRIPTION
- Adding DTrace probe for socket connections as `turtle-io*:::connection` which provides the current open socket connections, heapUsed & heapTotal stats
