### PR TITLE
Refactoring

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
 		"Last-Modified"               : ""
 	},
 	"index"   : ["index.htm", "index.html"],
-	"lag"     : 70,
+	"lag"     : 100,
 	"logs"    : {
 		"ext"    : "YYYYMMDD",
 		"file"   : "turtleio_{{ext}}.log",

--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2013 Jason Mulligan
  * @license BSD-3 <https://raw.github.com/avoidwork/turtle.io/master/LICENSE>
  * @link http://turtle.io
- * @version 0.6.6
+ * @version 0.6.7
  */
 ( function ( global ) {
 "use strict";
@@ -211,7 +211,7 @@ var factory = function ( args ) {
 	this.id      = "";
 	this.config  = {};
 	this.server  = null;
-	this.version = "0.6.6";
+	this.version = "0.6.7";
 
 	// Loading config
 	config.call( this, args );
@@ -245,7 +245,7 @@ factory.prototype.cache = function ( filename, obj, encoding, body ) {
 			raw.pipe( zlib[REGEX_DEF.test( encoding ) ? "createDeflate" : "createGzip"]() ).pipe( stream );
 
 			dtp.fire( "compress", function ( p ) {
-				return [obj, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
+				return [filename, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
 			});
 		});
 	}
@@ -267,7 +267,7 @@ factory.prototype.cache = function ( filename, obj, encoding, body ) {
 					if ( err ) self.log( err, true, false );
 					else {
 						dtp.fire( "compress", function ( p ) {
-							return [obj, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
+							return [filename, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
 						});
 					}
 				});
@@ -305,12 +305,12 @@ factory.prototype.cached = function ( filename, format, fn ) {
  * @param  {Object}  req     HTTP request Object
  * @param  {String}  etag    Etag header
  * @param  {String}  arg     Response body
- * @param  {Number}  code    Response status code
+ * @param  {Number}  status  Response status code
  * @param  {Object}  headers HTTP headers
  * @param  {Boolean} local   [Optional] Indicates arg is a file path, default is false
  * @return {Objet}           Instance
  */
-factory.prototype.compressed = function ( res, req, etag, arg, code, headers, local, timer ) {
+factory.prototype.compressed = function ( res, req, etag, arg, status, headers, local, timer ) {
 	local           = ( local === true );
 	timer           = timer || new Date();
 	var self        = this,
@@ -327,7 +327,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, code, headers, lo
 				});
 
 				if ( ready ) {
-					self.headers( res, req, code, headers );
+					self.headers( res, req, status, headers );
 					raw = fs.createReadStream( npath );
 					raw.pipe( res );
 				}
@@ -338,7 +338,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, code, headers, lo
 				}
 
 				dtp.fire( "respond", function ( p ) {
-					return [req.headers.host, req.method, req.url, code, diff( timer )];
+					return [req.headers.host, req.method, req.url, status, diff( timer )];
 				});
 			});
 		}
@@ -351,35 +351,70 @@ factory.prototype.compressed = function ( res, req, etag, arg, code, headers, lo
 			util.pump( raw, res );
 
 			dtp.fire( "respond", function ( p ) {
-				return [req.headers.host, req.method, req.url, code, diff( timer )];
+				return [req.headers.host, req.method, req.url, status, diff( timer )];
 			});
 		}
 	}
-	// Proxy response
+	// Custom or proxy route result
 	else {
-		if (compression !== null) {
-			res.setHeader( "Content-Encoding" , compression );
+		if ( compression !== null ) {
 			self.cached( etag, compression, function ( ready, npath ) {
-				dtp.fire( "compressed", function ( p ) {
-					return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
-				});
+				res.setHeader( "Content-Encoding" , compression );
 
+				// Responding with cached asset
 				if ( ready ) {
-					self.headers( res, req, code, headers );
+					dtp.fire( "compressed", function ( p ) {
+						return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+					});
+
+					self.headers( res, req, status, headers );
+
 					raw = fs.createReadStream( npath );
 					raw.pipe( res );
 
-					dtp.fire(" respond", function ( p ) {
-						return [req.headers.host, req.method, req.url, code, diff( timer )];
+					dtp.fire( "respond", function ( p ) {
+						return [req.headers.host, req.method, req.url, status, diff( timer )];
 					});
 				}
+				// Compressing asset & writing to disk after responding
 				else {
-					self.cache( etag, arg, compression, true );
-					self.respond( res, req, arg, code, headers, timer );
+					zlib[compression]( arg, function ( err, compressed ) {
+						dtp.fire( "compressed", function ( p ) {
+							return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+						});
+
+						if ( err ) {
+							self.error( res, req, timer );
+						}
+						else {
+							self.headers( res, req, status, headers );
+							res.write( compressed );
+							res.end();
+
+							dtp.fire( "respond", function ( p ) {
+								return [req.headers.host, req.method, req.url, status, diff( timer )];
+							});
+
+							fs.writeFile( npath, compressed, function ( e ) {
+								if ( err ) {
+									self.log( err, true, false );
+								}
+								else {
+									dtp.fire( "compress", function ( p ) {
+										return [etag, npath, compression, diff( timer )];
+									});
+								}
+							});
+
+							self.log( prep.call( self, res, req ) );
+						}
+					});
 				}
 			});
 		}
-		else this.respond( res, req, arg, code, headers, timer, false );
+		else {
+			this.respond( res, req, arg, code, headers, timer, false );
+		}
 	}
 
 	return this;
@@ -991,28 +1026,25 @@ factory.prototype.respond = function ( res, req, output, status, responseHeaders
 		}
 	}
 
-	// Setting the response status code
-	res.statusCode = status;	
-
-	if ( compress ) {
-		responseHeaders["Content-Encoding"] = encoding;
-		zlib[encoding](output, function ( err, compressed ) {
-			if ( err ) {
-				self.error( res, req );
-			}
-			else {
-				self.headers( res, req, status, responseHeaders );
-				res.write( compressed );
-				res.end();
-
-				dtp.fire( "respond", function ( p ) {
-					return [req.headers.host, req.method, req.url, status, diff( timer )];
-				});
-
-				self.log( prep.call( self, res, req ) );
-			}
-		});
+	// Setting Etag if not present
+	if (responseHeaders.Etag === undefined) {
+		responseHeaders.Etag = "\"" + self.hash( req.url + "-" + output.length + "-" + output ) + "\"";
 	}
+
+	// Comparing against request headers incase this is a custom route response
+	if (req.headers["if-none-match"] === responseHeaders.Etag) {
+		status = 304;
+		output = messages.NO_CONTENT;
+	}
+
+	// Setting the response status code
+	res.statusCode = status;
+
+	// Compressing response to disk
+	if ( status !== 304 && compress ) {
+		self.compressed( res, req, responseHeaders.Etag.replace(/"/g, ""), output, status, responseHeaders, false, timer );
+	}
+	// Serving content
 	else {
 		this.headers( res, req, status, responseHeaders );
 
@@ -1056,8 +1088,8 @@ factory.prototype.start = function ( args ) {
 
 	// Default headers
 	headers = {
-		"Server"       : "turtle.io/0.6.6",
-		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8 + ")" ); } )()
+		"Server"       : "turtle.io/0.6.7",
+		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")" ); } )()
 	};
 
 	// Loading config
@@ -1452,7 +1484,7 @@ var messages = {
 	SUCCESS           : "Successful",
 	CREATED           : "Created",
 	ACCEPTED          : "Accepted",
-	NO_CONTENT        : "",
+	NO_CONTENT        : null,
 	INVALID_ARGUMENTS : "Invalid arguments",
 	INVALID_AUTH      : "Invalid authorization or OAuth token",
 	FORBIDDEN         : "Forbidden",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "abaaso": ">= 3.5.29",
+    "abaaso": ">= 3.5.30",
     "mime": ">= 1.2.7",
     "moment": ">= 1.7.0",
     "http-auth" : ">= 1.2.2",
@@ -42,5 +42,5 @@
     "grunt-contrib-concat"   : "~ 0.1.3",
     "grunt-contrib-nodeunit" : "~ 0.1.2"
   },
-  "keywords": ["web server", "http", "https", "web", "server", "virtual hosts"]
+  "keywords": ["web server", "http", "https", "web", "server", "virtual", "virtual hosts", "proxy", "api", "cache", "application"]
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -24,7 +24,7 @@ factory.prototype.cache = function ( filename, obj, encoding, body ) {
 			raw.pipe( zlib[REGEX_DEF.test( encoding ) ? "createDeflate" : "createGzip"]() ).pipe( stream );
 
 			dtp.fire( "compress", function ( p ) {
-				return [obj, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
+				return [filename, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
 			});
 		});
 	}
@@ -46,7 +46,7 @@ factory.prototype.cache = function ( filename, obj, encoding, body ) {
 					if ( err ) self.log( err, true, false );
 					else {
 						dtp.fire( "compress", function ( p ) {
-							return [obj, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
+							return [filename, dest, REGEX_DEF.test( encoding ) ? "deflate" : "gzip", diff( timer )];
 						});
 					}
 				});

--- a/src/messages.js
+++ b/src/messages.js
@@ -7,7 +7,7 @@ var messages = {
 	SUCCESS           : "Successful",
 	CREATED           : "Created",
 	ACCEPTED          : "Accepted",
-	NO_CONTENT        : "",
+	NO_CONTENT        : null,
 	INVALID_ARGUMENTS : "Invalid arguments",
 	INVALID_AUTH      : "Invalid authorization or OAuth token",
 	FORBIDDEN         : "Forbidden",

--- a/src/start.js
+++ b/src/start.js
@@ -13,7 +13,7 @@ factory.prototype.start = function ( args ) {
 	// Default headers
 	headers = {
 		"Server"       : "turtle.io/{{VERSION}}",
-		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8 + ")" ); } )()
+		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")" ); } )()
 	};
 
 	// Loading config


### PR DESCRIPTION
- Upgrading abaaso version dependency
- Changing `compress` dtrace probe to return the Etag instead of data
- Changing `messages.NO_CONTENT`to be `null`
- Refactoring `respond()` to assign an Etag if one is not present based on `url-body` & responding with a `304` when appropriate
- Refactored `server.compressed()` to create the cached version on disk from the result of a non-local (disk) response instead of calling `cache()` which essentially scheduled two compressions
