### PR TITLE
Major fixes

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
 	"logs"    : {
 		"ext"    : "YYYYMMDD",
 		"file"   : "turtleio_{{ext}}.log",
-		"time"   : "D/MMM/YYYY:HH:MM:SS ZZ",
+		"time"   : "D/MMM/YYYY:HH:mm:ss ZZ",
 		"format" : "{{ip}} - {{user}} [{{time}}] \"{{method}} {{path}} HTTP/1.1\" {{status}} {{length}} {{referer}} \"{{user-agent}}\""
 	},
 	"port"    : 8000,

--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2013 Jason Mulligan
  * @license BSD-3 <https://raw.github.com/avoidwork/turtle.io/master/LICENSE>
  * @link http://turtle.io
- * @version 0.6.9
+ * @version 0.6.10
  */
 ( function ( global ) {
 "use strict";
@@ -210,7 +210,7 @@ var factory = function ( args ) {
 	this.id      = "";
 	this.config  = {};
 	this.server  = null;
-	this.version = "0.6.9";
+	this.version = "0.6.10";
 
 	// Loading config
 	config.call( this, args );
@@ -322,7 +322,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 			res.setHeader( "Content-Encoding", compression );
 			self.cached( etag, compression, function ( ready, npath ) {
 				dtp.fire( "compressed", function ( p ) {
-					return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+					return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 				});
 
 				if ( ready ) {
@@ -343,7 +343,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 		}
 		else {
 			dtp.fire( "compressed", function ( p ) {
-				return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+				return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 			});
 
 			raw = fs.createReadStream( arg );
@@ -363,7 +363,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 				// Responding with cached asset
 				if ( ready ) {
 					dtp.fire( "compressed", function ( p ) {
-						return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+						return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 					});
 
 					self.headers( res, req, status, headers );
@@ -379,7 +379,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 				else {
 					zlib[compression]( arg, function ( err, compressed ) {
 						dtp.fire( "compressed", function ( p ) {
-							return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+							return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 						});
 
 						if ( err ) {
@@ -769,17 +769,16 @@ factory.prototype.proxy = function ( origin, route, host ) {
  * @return {Object}            instance
  */
 factory.prototype.redirect = function ( route, url, host, permanent ) {
-	var self   = this,
-	    code   = codes[permanent === true ? "MOVED" : "REDIRECT"],
-	    output = messages.NO_CONTENT,
-	    timer  = new Date();
+	var self  = this,
+	    code  = codes[permanent === true ? "MOVED" : "REDIRECT"],
+	    timer = new Date();
 
-	this.get( route, function ( res, req ) {
-		self.respond( res, req, output, code, {"Location": url}, new Date() );
+	this.get( route, function ( res, req, timer ) {
+		self.respond( res, req, messages.NO_CONTENT, code, {"Location": url}, timer, false );
 	}, host);
 
 	dtp.fire( "redirect-set", function ( p ) {
-		return [req.headers.host, route, url, permanent, diff( timer )];
+		return [host || "*", route, url, permanent, diff( timer )];
 	});
 
 	return this;
@@ -993,7 +992,7 @@ factory.prototype.respond = function ( res, req, output, status, responseHeaders
 	status = status || codes.SUCCESS;
 	timer  = timer  || new Date(); // Not ideal! This gives a false sense of speed for custom routes
 
-	var body      = !REGEX_HEAD.test(req.method),
+	var body      = !REGEX_HEAD.test(req.method) && output !== null,
 	    encoding  = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
 	    self      = this,
 	    nth, salt;
@@ -1022,7 +1021,7 @@ factory.prototype.respond = function ( res, req, output, status, responseHeaders
 
 	// Setting Etag if not present
 	if (responseHeaders.Etag === undefined) {
-		salt = req.url + "-" + req.method + "-" + ( output.length || null ) + "-" + output;
+		salt = req.url + "-" + req.method + "-" + ( output !== null && typeof output.length !== "undefined" ? output.length : null ) + "-" + output;
 		responseHeaders.Etag = "\"" + self.hash( salt ) + "\"";
 	}
 
@@ -1083,7 +1082,7 @@ factory.prototype.start = function ( args ) {
 
 	// Default headers
 	headers = {
-		"Server"       : "turtle.io/0.6.9",
+		"Server"       : "turtle.io/0.6.10",
 		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")" ); } )()
 	};
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",

--- a/src/compressed.js
+++ b/src/compressed.js
@@ -23,7 +23,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 			res.setHeader( "Content-Encoding", compression );
 			self.cached( etag, compression, function ( ready, npath ) {
 				dtp.fire( "compressed", function ( p ) {
-					return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+					return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 				});
 
 				if ( ready ) {
@@ -44,7 +44,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 		}
 		else {
 			dtp.fire( "compressed", function ( p ) {
-				return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+				return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 			});
 
 			raw = fs.createReadStream( arg );
@@ -64,7 +64,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 				// Responding with cached asset
 				if ( ready ) {
 					dtp.fire( "compressed", function ( p ) {
-						return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+						return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 					});
 
 					self.headers( res, req, status, headers );
@@ -80,7 +80,7 @@ factory.prototype.compressed = function ( res, req, etag, arg, status, headers, 
 				else {
 					zlib[compression]( arg, function ( err, compressed ) {
 						dtp.fire( "compressed", function ( p ) {
-							return [etag, local ? "local" : "proxy", req.headers.host, req.url, diff( timer )];
+							return [etag, local ? "local" : "custom", req.headers.host, req.url, diff( timer )];
 						});
 
 						if ( err ) {

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -8,17 +8,16 @@
  * @return {Object}            instance
  */
 factory.prototype.redirect = function ( route, url, host, permanent ) {
-	var self   = this,
-	    code   = codes[permanent === true ? "MOVED" : "REDIRECT"],
-	    output = messages.NO_CONTENT,
-	    timer  = new Date();
+	var self  = this,
+	    code  = codes[permanent === true ? "MOVED" : "REDIRECT"],
+	    timer = new Date();
 
-	this.get( route, function ( res, req ) {
-		self.respond( res, req, output, code, {"Location": url}, new Date() );
+	this.get( route, function ( res, req, timer ) {
+		self.respond( res, req, messages.NO_CONTENT, code, {"Location": url}, timer, false );
 	}, host);
 
 	dtp.fire( "redirect-set", function ( p ) {
-		return [req.headers.host, route, url, permanent, diff( timer )];
+		return [host || "*", route, url, permanent, diff( timer )];
 	});
 
 	return this;

--- a/src/respond.js
+++ b/src/respond.js
@@ -15,7 +15,7 @@ factory.prototype.respond = function ( res, req, output, status, responseHeaders
 	status = status || codes.SUCCESS;
 	timer  = timer  || new Date(); // Not ideal! This gives a false sense of speed for custom routes
 
-	var body      = !REGEX_HEAD.test(req.method),
+	var body      = !REGEX_HEAD.test(req.method) && output !== null,
 	    encoding  = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
 	    self      = this,
 	    nth, salt;
@@ -44,7 +44,7 @@ factory.prototype.respond = function ( res, req, output, status, responseHeaders
 
 	// Setting Etag if not present
 	if (responseHeaders.Etag === undefined) {
-		salt = req.url + "-" + req.method + "-" + ( output.length || null ) + "-" + output;
+		salt = req.url + "-" + req.method + "-" + ( output !== null && typeof output.length !== "undefined" ? output.length : null ) + "-" + output;
 		responseHeaders.Etag = "\"" + self.hash( salt ) + "\"";
 	}
 


### PR DESCRIPTION
- Fixing #76 by correcting the default time format for logging
- Fixing `redirect()` by passing an explicit instruction to `respond()`
- Fixing `respond()` by properly handling `null` as the output
