### PR TITLE
Minor changes

### DIFF
--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2013 Jason Mulligan
  * @license BSD-3 <https://raw.github.com/avoidwork/turtle.io/master/LICENSE>
  * @link http://turtle.io
- * @version 0.8.1
+ * @version 0.8.2
  */
 ( function ( global ) {
 "use strict";
@@ -27,6 +27,7 @@ var $          = require( "abaaso" ),
     d          = require( "dtrace-provider" ),
     dtp        = d.createDTraceProvider( "turtle-io" ),
     REGEX_BODY = /^(put|post|patch)$/i,
+    REGEX_CSV  = /text\/csv/,
     REGEX_HALT = new RegExp( "^(ReferenceError|" + $.label.error.invalidArguments + ")$" ),
     REGEX_HEAD = /^(head|options)$/i,
     REGEX_HEAD2= /head|options/i,
@@ -35,7 +36,9 @@ var $          = require( "abaaso" ),
     REGEX_DEF  = /deflate/,
     REGEX_GZIP = /gzip/,
     REGEX_IE   = /msie/i,
-    REGEX_DIR  = /\/$/;
+    REGEX_DIR  = /\/$/,
+    REGEX_NVAL = /;.*/,
+    REGEX_NURI = ".*\//";
 
 // Hooking syslog output
 syslog.init( "turtle_io", syslog.LOG_PID | syslog.LOG_ODELAY, syslog.LOG_LOCAL0 );
@@ -241,7 +244,7 @@ var factory = function ( args ) {
 	};
 	this.logQueue     = [];
 	this.server       = null;
-	this.version      = "0.8.1";
+	this.version      = "0.8.2";
 
 	// Loading config
 	config.call( this, args );
@@ -1221,13 +1224,12 @@ factory.prototype.request = function ( res, req, timer ) {
  * @return {Objet}            Instance
  */
 factory.prototype.respond = function ( res, req, output, status, headers, timer, compress ) {
-	status   = status || codes.SUCCESS;
-	timer    = timer  || new Date(); // Not ideal! This gives a false sense of speed for custom routes
-	compress = ( compress === true );
-
-	var body      = !REGEX_HEAD.test(req.method) && output !== null,
-	    encoding  = this.compression(req.headers["user-agent"], req.headers["accept-encoding"]),
-	    self      = this,
+	status       = status || codes.SUCCESS;
+	timer        = timer  || new Date(); // Not ideal! This gives a false sense of speed for custom routes
+	compress     = ( compress === true );
+	var body     = !REGEX_HEAD.test( req.method ) && output !== null,
+	    encoding = this.compression( req.headers["user-agent"], req.headers["accept-encoding"] ),
+	    self     = this,
 	    nth, salt;
 
 	if ( !( headers instanceof Object ) ) {
@@ -1245,20 +1247,33 @@ factory.prototype.respond = function ( res, req, output, status, headers, timer,
 		headers["Content-Type"] = "application/json";
 	}
 
-	// Setting Etag if not present
-	if (headers.Etag === undefined) {
-		salt = req.url + "-" + req.method + "-" + ( output !== null && typeof output.length !== "undefined" ? output.length : null ) + "-" + output;
-		headers.Etag = "\"" + self.hash( salt ) + "\"";
+	if ( status === 200 ) {
+		// CSV hook
+		if ( headers["Content-Type"] === "application/json" && REGEX_CSV.test( req.headers["accept"].explode()[0].replace( REGEX_NVAL, "" ) ) ) {
+			headers["Content-Type"] = "text/csv";
+
+			if ( headers["Content-Disposition"] === undefined ) {
+				headers["Content-Disposition"] = "attachment; filename=\"" + req.url.replace( REGEX_NURI, "" ) + ".csv\"";
+			}
+
+			output = $.json.csv( body );
+		}
+
+		// Setting Etag if not present
+		if ( headers.Etag === undefined ) {
+			salt = req.url + "-" + req.method + "-" + $.encode( req.headers ) + "-" + ( output !== null && typeof output.length !== "undefined" ? output.length : null ) + "-" + output;
+			headers.Etag = "\"" + self.hash( salt ) + "\"";
+		}
 	}
 
 	// Comparing against request headers incase this is a custom route response
-	if (req.headers["if-none-match"] === headers.Etag) {
+	if ( req.headers["if-none-match"] === headers.Etag ) {
 		status = 304;
 		body   = false;
 	}
 
 	// Compressing response to disk
-	if ( status !== 304 && compress ) {
+	if ( status === 200 && compress ) {
 		self.compressed( res, req, headers.Etag.replace(/"/g, ""), output, status, headers, false, timer );
 	}
 	// Serving content
@@ -1333,7 +1348,7 @@ factory.prototype.start = function ( args, fn ) {
 
 	// Default headers
 	headers = {
-		"Server"       : "turtle.io/0.8.1",
+		"Server"       : "turtle.io/0.8.2",
 		"X-Powered-By" : ( function () { return ( "abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + " (" + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")" ); } )()
 	};
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "abaaso": "~3.7.2",
+    "abaaso": "~3.7.12",
     "mime": "~1.2.9",
     "moment": "~2.0.0",
     "http-auth" : "~1.2.7",

--- a/src/intro.js
+++ b/src/intro.js
@@ -16,6 +16,7 @@ var $          = require( "abaaso" ),
     d          = require( "dtrace-provider" ),
     dtp        = d.createDTraceProvider( "turtle-io" ),
     REGEX_BODY = /^(put|post|patch)$/i,
+    REGEX_CSV  = /text\/csv/,
     REGEX_HALT = new RegExp( "^(ReferenceError|" + $.label.error.invalidArguments + ")$" ),
     REGEX_HEAD = /^(head|options)$/i,
     REGEX_HEAD2= /head|options/i,
@@ -24,7 +25,9 @@ var $          = require( "abaaso" ),
     REGEX_DEF  = /deflate/,
     REGEX_GZIP = /gzip/,
     REGEX_IE   = /msie/i,
-    REGEX_DIR  = /\/$/;
+    REGEX_DIR  = /\/$/,
+    REGEX_NVAL = /;.*/,
+    REGEX_NURI = ".*\//";
 
 // Hooking syslog output
 syslog.init( "turtle_io", syslog.LOG_PID | syslog.LOG_ODELAY, syslog.LOG_LOCAL0 );


### PR DESCRIPTION
- Only decorating `Etag` headers on `200` status codes & fixing #99
- Adding automatic `JSON` to `CSV` transformation if `Client` indicates it's the desired format
