### PR TITLE
Minor fix

### DIFF
--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -305,7 +305,9 @@ factory.prototype.bootstrap = function ( fn ) {
 		}
 
 		// Setting default response route
-		this.get( "/.*", this.request );
+		if ( !this.routes().get.contains( "/.*" ) ) {
+			this.get( "/.*", this.request );
+		}
 
 		// Creating a server
 		this.active = true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & RESTful proxies",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "abaaso": "~3.7.29",
+    "abaaso": "~3.7.35",
     "mime": "~1.2.9",
     "moment": "~2.0.0",
     "http-auth" : "~1.2.7",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -55,7 +55,9 @@ factory.prototype.bootstrap = function ( fn ) {
 		}
 
 		// Setting default response route
-		this.get( "/.*", this.request );
+		if ( !this.routes().get.contains( "/.*" ) ) {
+			this.get( "/.*", this.request );
+		}
 
 		// Creating a server
 		this.active = true;


### PR DESCRIPTION
- Fixing `this.bootstrap()` so a custom GET route for "/.*" is not overridden
