### PR TITLE
Minor version bump to update npm deps

### DIFF
--- a/lib/turtle.io.js
+++ b/lib/turtle.io.js
@@ -7,7 +7,7 @@
  * @copyright 2013 Jason Mulligan
  * @license BSD-3 <https://raw.github.com/avoidwork/turtle.io/master/LICENSE>
  * @link http://turtle.io
- * @version 1.0.0
+ * @version 1.0.1
  */
 "use strict";
 
@@ -1572,7 +1572,7 @@ TurtleIO.prototype.start = function ( cfg, err ) {
 
 	// Setting `Server` HTTP header
 	if ( !this.config.headers.Server ) {
-		this.config.headers.Server = "turtle.io/1.0.0 (abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")";
+		this.config.headers.Server = "turtle.io/1.0.1 (abaaso/" + $.version + " node.js/" + process.versions.node.replace( /^v/, "" ) + process.platform.capitalize() + " V8/" + process.versions.v8.toString().trim() + ")";
 	}
 
 	// Creating REGEX_REWRITE

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turtle.io",
   "description": "Easy to use web server with virtual hosts & reverse proxies",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "http://turtle.io",
   "author": {
     "name": "Jason Mulligan",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "abaaso": "3.10.42",
+    "abaaso": "3.10.43",
     "mime": "1.2.11",
     "moment": "2.4.0",
     "http-auth" : "1.2.9",


### PR DESCRIPTION
- Updating abaaso dependency to 3.10.43 to remove an erroneous error that could happen while making requests for erroneous data (e.g. invalid data, a 500 response is expected); which can be triggered with a reverse proxy
