### PR TITLE
Fix TypeError on TurtleIO.stop

### DIFF
--- a/lib/turtleio.js
+++ b/lib/turtleio.js
@@ -475,7 +475,7 @@ class TurtleIO {
 	stop () {
 		if (this.server) {
 			// Stopping inbound requests
-			this.server.stop();
+			this.server.close();
 			this.server = null;
 
 			// Clearing watchers


### PR DESCRIPTION
TurtleIO.stop raises `TypeError: this.server.stop is not a function` because said method does not exist,  **server.close** should be used instead (seen at https://nodejs.org/api/http.html#http_server_close_callback).